### PR TITLE
Script improvements

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -18,11 +18,22 @@ set -x
 set -o errexit
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 EXAMPLESDIR=$GOPATH/src/github.com/amalgam8/examples
+EXAMPLESREPO=https://github.com/amalgam8/examples
 
-# If examples directory does not exist, clone repo from github
-if [ ! -d "$EXAMPLESDIR" ]; then
-    git clone --branch master https://github.com/amalgam8/examples $EXAMPLESDIR
+#from https://gist.github.com/nicferrier/2277987
+LOCALREPO=$EXAMPLESDIR
+
+# We do it this way so that we can abstract if from just git later on
+LOCALREPO_VC_DIR=$EXAMPLESREPO/.git
+
+if [ ! -d $LOCALREPO_VC_DIR ]
+then
+    git clone $EXAMPLESREPO $EXAMPLESDIR
+else
+    cd $EXAMPLESDIR && git pull $EXAMPLESREPO
 fi
+
+# End
 
 $SCRIPTDIR/build-scripts/build-amalgam8.sh
 

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -18,7 +18,11 @@ set -x
 set -o errexit
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 EXAMPLESDIR=$GOPATH/src/github.com/amalgam8/examples
-git clone --branch master https://github.com/amalgam8/examples $EXAMPLESDIR
+
+# If examples directory does not exist, clone repo from github
+if [ ! -d "$EXAMPLESDIR" ]; then
+    git clone --branch master https://github.com/amalgam8/examples $EXAMPLESDIR
+fi
 
 $SCRIPTDIR/build-scripts/build-amalgam8.sh
 
@@ -50,3 +54,5 @@ sleep 60
 $SCRIPTDIR/testing/demo_script.sh
 echo "Kubernetes tests successful. Cleaning up.."
 $EXAMPLESDIR/kubernetes/cleanup.sh
+sleep 5
+sudo $EXAMPLESDIR/kubernetes/uninstall-kubernetes.sh

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -33,6 +33,7 @@ else
     cd $EXAMPLESDIR && git pull $EXAMPLESREPO
 fi
 
+cd $EXAMPLESDIR && git checkout master
 # End
 
 $SCRIPTDIR/build-scripts/build-amalgam8.sh


### PR DESCRIPTION
Only does a git clone of examples if the directory does not already exist.

Also, end the kubernetes test portion with uninstall-kubernetes - since it was installed as part of the test initially.  Makes it easier for users to run the script in repetition for development